### PR TITLE
Refactor namespaces and restore Person class

### DIFF
--- a/PhoneBookAPI/Controllers/PeopleController.cs
+++ b/PhoneBookAPI/Controllers/PeopleController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using PhonebookApi.Models;
 using PhonebookApi.Repositories.Interfaces;
+using PhoneBookAPI.Data;
 
 namespace PhonebookApi.Controllers
 {

--- a/PhoneBookAPI/Data/AppDbContext.cs
+++ b/PhoneBookAPI/Data/AppDbContext.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using PhonebookApi.Models;
+using PhoneBookAPI.Data;
 
 namespace PhonebookApi.Data
 {

--- a/PhoneBookAPI/Data/Person.cs
+++ b/PhoneBookAPI/Data/Person.cs
@@ -1,4 +1,4 @@
-﻿namespace PhonebookApi.Models
+﻿namespace PhoneBookAPI.Data
 {
     public class Person
     {

--- a/PhoneBookAPI/Mapping/MappingProfile.cs
+++ b/PhoneBookAPI/Mapping/MappingProfile.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using PhonebookApi.Dtos;
-using PhonebookApi.Models;
+using PhoneBookAPI.Data;
 
 namespace PhonebookApi.Mapping
 {

--- a/PhoneBookAPI/Repositories/Interfaces/IPersonRepository.cs
+++ b/PhoneBookAPI/Repositories/Interfaces/IPersonRepository.cs
@@ -1,4 +1,4 @@
-﻿using PhonebookApi.Models;
+﻿using PhoneBookAPI.Data;
 
 namespace PhonebookApi.Repositories.Interfaces
 {

--- a/PhoneBookAPI/Repositories/PersonRepository.cs
+++ b/PhoneBookAPI/Repositories/PersonRepository.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using PhonebookApi.Data;
-using PhonebookApi.Models;
 using PhonebookApi.Repositories.Interfaces;
+using PhoneBookAPI.Data;
 
 namespace PhonebookApi.Repositories
 {


### PR DESCRIPTION
Updated namespace from `PhonebookApi.Models` to `PhoneBookAPI.Data` across multiple files. Restored the `Person` class definition in `Person.cs` and modified `using` statements in `AppDbContext`, `MappingProfile`, `IPersonRepository`, and `PersonRepository` to reflect the new namespace.